### PR TITLE
chore: modernize Salesforce CLI commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ We've built a simple application that demonstrates how LaunchDarkly's SDK works.
 
 Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit the [Apex SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/apex).
 
-This guide requires you to install the [Salesforce CLI](https://developer.salesforce.com/tools/sfdxcli) and the [Go compiler](https://golang.org/).
+This guide requires you to install the [Salesforce CLI](https://developer.salesforce.com/tools/salesforcecli) and the [Go compiler](https://golang.org/).
 
 ## Build instructions
 
@@ -18,7 +18,7 @@ git clone https://github.com/launchdarkly/apex-server-sdk.git
 
 ```bash
 cd apex-server-sdk
-sfdx force:source:deploy --targetusername='YOUR TARGET ORG' --sourcepath='force-app'
+sf project deploy start --target-org 'YOUR TARGET ORG' --source-dir 'force-app'
 ```
 
 3. Build the Salesforce LaunchDarkly bridge.
@@ -57,5 +57,5 @@ String flagKey = 'my-boolean-flag';
 6. Use the SDK with `hello.apex`
 
 ```bash
-sfdx force:apex:execute --targetusername='YOUR TARGET ORG' --apexcodefile='hello.apex'
+sf apex run --target-org 'YOUR TARGET ORG' --file 'hello.apex'
 ```


### PR DESCRIPTION
## Summary

The README used deprecated `sfdx force:*` commands, which are removed from the current Salesforce CLI (`sf`). Updated them to the current equivalents (flag names verified against the installed `@salesforce/cli`):

- Deploy: `sfdx force:source:deploy --targetusername=… --sourcepath='force-app'` → `sf project deploy start --target-org … --source-dir 'force-app'`
- Execute: `sfdx force:apex:execute --targetusername=… --apexcodefile='hello.apex'` → `sf apex run --target-org … --file 'hello.apex'`
- Install link: `developer.salesforce.com/tools/sfdxcli` → `developer.salesforce.com/tools/salesforcecli`

Docs-only change; this example needs a live Salesforce org to run end-to-end, so no runtime test.

Link to Devin session: https://app.devin.ai/sessions/8148ac8939db4960ab05f5ce5b6e061d
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application code, auth, or runtime behavior changes.
> 
> **Overview**
> Updates the Apex sample **README** so setup steps match the current Salesforce CLI (`sf`), replacing removed `sfdx force:*` invocations.
> 
> **Deploy** instructions now use `sf project deploy start` with `--target-org` and `--source-dir` instead of `force:source:deploy` with `--targetusername` / `--sourcepath`. **Apex execution** uses `sf apex run` with `--file` instead of `force:apex:execute` with `--apexcodefile`. The **CLI install link** points to `salesforcecli` rather than `sfdxcli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189130e166621bf4be349b27e85991cc56812c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->